### PR TITLE
Fix invalidate_dependencies

### DIFF
--- a/src/affinitic/caching/memcached.py
+++ b/src/affinitic/caching/memcached.py
@@ -25,10 +25,12 @@ else:  # we have sqlalchemy
         from sqlalchemy.engine import RowProxy
 
 
+from lovely.memcached.event import invalidateCache
 from lovely.memcached.event import InvalidateCacheEvent
 from lovely.memcached.interfaces import IMemcachedClient
 from lovely.memcached.utility import MemcachedClient
 
+from zope import component
 from zope import event
 from zope.component import queryUtility
 from zope.ramcache.interfaces.ram import IRAMCache
@@ -185,6 +187,7 @@ def invalidate_dependencies(dependencies):
     Invalidate all caches linked to dependencies
     """
     client = queryUtility(IMemcachedClient)
+    component.provideHandler(invalidateCache)
     # memcached
     if client is not None:
         invalidateEvent = InvalidateCacheEvent(raw=True,


### PR DESCRIPTION
Indeed, as you seems in lovely memcached tests :
https://github.com/lovelysystems/lovely.memcached/blob/master/src/lovely/memcached/README.txt#L301-L302

invalidateCache need a component provideHandler method to work
